### PR TITLE
Remove remark-validate-links

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,7 +20,4 @@ exports.plugins = [
   // External rules
   "remark-lint-match-punctuation",
   "remark-lint-no-dead-urls",
-
-  // Plugins
-  "remark-validate-links",
 ];

--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
     "remark-lint-no-shortcut-reference-image": "^1.0.3",
     "remark-lint-no-shortcut-reference-link": "^1.0.4",
     "remark-lint-no-undefined-references": "^1.1.1",
-    "remark-lint-no-unused-definitions": "^1.0.5",
-    "remark-validate-links": "^9.2.0"
+    "remark-lint-no-unused-definitions": "^1.0.5"
   }
 }


### PR DESCRIPTION
[remark-validate-links](https://github.com/remarkjs/remark-validate-links) scans users' `.git` directory.
So the plugin is not a pure lint rule.