### PR TITLE
Disable `package-lock`

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+package-lock = false


### PR DESCRIPTION
To prevent the following warning:

```console
$ npm install
npm notice created a lockfile as package-lock.json. You should commit this file.
...
```