### PR TITLE
Remove `open-pull-requests-limit` for Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,5 +6,4 @@ updates:
     interval: weekly
     time: "09:00"
     timezone: Asia/Tokyo
-  open-pull-requests-limit: 10
   versioning-strategy: increase


### PR DESCRIPTION
I believe the limit is not useful for this project.