### PR TITLE
Fix deprecated `set-env` in GitHub Action

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,7 +15,7 @@ jobs:
           registry-url: https://registry.npmjs.org/
       - run: npm install
       - run: npm test
-      - run: echo "::set-env name=NPM_CONFIG_TAG::next"
+      - run: echo "NPM_CONFIG_TAG=next" >> $GITHUB_ENV
         if: ${{ github.event.release.prerelease }}
       - run: npm publish
         env:

--- a/goodcheck.yml
+++ b/goodcheck.yml
@@ -1,0 +1,7 @@
+import:
+  - https://raw.githubusercontent.com/sider/goodcheck-rules/master/rules/typo.yml
+  - https://raw.githubusercontent.com/sider/goodcheck-rules/master/rules/github.yml
+
+exclude:
+  - node_modules
+  - package-lock.json


### PR DESCRIPTION
See also:
- https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/
- https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-commands-for-github-actions#environment-files

Also, this change introduces the useful Goodcheck rules.