### PR TITLE
Add `remark-gfm`

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,4 +20,7 @@ exports.plugins = {
   // External rules
   "remark-lint-match-punctuation": true,
   "remark-lint-no-dead-urls": [true, { skipLocalhost: true, skipOffline: true }],
+
+  // Plugins
+  "remark-gfm": true,
 };

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "remark-lint": "^8.0.0"
   },
   "dependencies": {
+    "remark-gfm": "^1.0.0",
     "remark-lint-heading-increment": "^2.0.1",
     "remark-lint-match-punctuation": "^0.2.0",
     "remark-lint-no-auto-link-without-protocol": "^2.0.1",

--- a/test/test.md
+++ b/test/test.md
@@ -1,0 +1,2 @@
+- [ ] Check 1
+- [ ] Check 2


### PR DESCRIPTION
Sider run mostly on GitHub, so I think it makes sense to support GitHub Flavored Markdown.
See <https://github.com/remarkjs/remark-gfm>.