### PR TITLE
Add `remark-frontmatter`

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,5 +22,6 @@ exports.plugins = {
   "remark-lint-no-dead-urls": [true, { skipLocalhost: true, skipOffline: true }],
 
   // Plugins
+  "remark-frontmatter": true,
   "remark-gfm": true,
 };

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "remark-lint": "^8.0.0"
   },
   "dependencies": {
+    "remark-frontmatter": "^3.0.0",
     "remark-gfm": "^1.0.0",
     "remark-lint-heading-increment": "^2.0.1",
     "remark-lint-match-punctuation": "^0.2.0",

--- a/test/test.md
+++ b/test/test.md
@@ -1,2 +1,9 @@
+---
+id: test
+title: This is a front-matter
+---
+
+# Test
+
 - [ ] Check 1
 - [ ] Check 2


### PR DESCRIPTION
Like Gatsby or Docusaurus, frameworks allowing frontmatter increases.
So, I think it makes sense to support frontmatter by default.

See <https://github.com/remarkjs/remark-frontmatter>.

See also:
- https://www.gatsbyjs.com/docs/how-to/routing/adding-markdown-pages/#frontmatter-for-metadata-in-markdown-files
- https://docusaurus.io/docs/en/doc-markdown