### PR TITLE
Remove `remark-lint-match-punctuation` rule

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,7 +18,6 @@ exports.plugins = {
   "remark-lint-no-unused-definitions": true,
 
   // External rules
-  "remark-lint-match-punctuation": true,
   "remark-lint-no-dead-urls": [true, { skipLocalhost: true, skipOffline: true }],
 
   // Plugins

--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     "remark-frontmatter": "^3.0.0",
     "remark-gfm": "^1.0.0",
     "remark-lint-heading-increment": "^2.0.1",
-    "remark-lint-match-punctuation": "^0.2.0",
     "remark-lint-no-auto-link-without-protocol": "^2.0.1",
     "remark-lint-no-blockquote-without-marker": "^4.0.0",
     "remark-lint-no-dead-urls": "^1.1.0",


### PR DESCRIPTION
**BREAKING CHANGE**

The code is below:
<https://github.com/laysent/remark-lint-plugins/tree/remark-lint-match-punctuation%400.2.0/packages/remark-lint-match-punctuation>

Reason:
This rule is specific to particular languages, so it is not suitable for our generic recommended ruleset.